### PR TITLE
Unbreak account_open_metadata

### DIFF
--- a/fava_investor/common/favainvestorapi.py
+++ b/fava_investor/common/favainvestorapi.py
@@ -1,5 +1,6 @@
 from beancount.core import getters
 from fava.template_filters import cost_or_value
+from beancount.core.data import Open
 
 
 class FavaInvestorAPI:
@@ -35,6 +36,11 @@ class FavaInvestorAPI:
 
     def get_account_open_close(self):
         return getters.get_account_open_close(self.ledger.entries)
+
+    def get_account_open(self):
+        oc = getters.get_account_open_close(self.entries)
+        opens = [e for e in oc if isinstance(e, Open)]
+        return opens
 
     def cost_or_value(self, node, date, include_children):
         if include_children:

--- a/fava_investor/modules/assetalloc_account/libaaacc.py
+++ b/fava_investor/modules/assetalloc_account/libaaacc.py
@@ -47,7 +47,7 @@ def by_account_open_metadata(accapi, config):
     selected_accounts = []
     include_children = config.get('include_children', False)
     regexer = re.compile(pattern)
-    for entry in accapi.all_entries_by_type[Open]:
+    for entry in accapi.get_account_open():
         if metadata_key in entry.meta and regexer.match(entry.meta[metadata_key]) is not None:
             selected_accounts.append(entry.account)
 


### PR DESCRIPTION
all_entries_by_type doesn't exist, leading to breakage:

        for entry in accapi.all_entries_by_type[Open]:
    AttributeError: 'FavaInvestorAPI' object has no attribute 'all_entries_by_type'

Fixes #35