### PR TITLE
fix get_commodity_map

### DIFF
--- a/fava_investor/common/beancountinvestorapi.py
+++ b/fava_investor/common/beancountinvestorapi.py
@@ -17,8 +17,8 @@ class AccAPI:
     def build_price_map(self):
         return prices.build_price_map(self.entries)
 
-    def get_commodity_map(self):
-        return getters.get_commodity_map(self.entries)
+    def get_commodity_directives(self):
+        return getters.get_commodity_directives(self.entries)
 
     def realize(self):
         return realization.realize(self.entries)

--- a/fava_investor/common/favainvestorapi.py
+++ b/fava_investor/common/favainvestorapi.py
@@ -13,8 +13,8 @@ class FavaInvestorAPI:
     def build_price_map(self):
         return self.ledger.price_map
 
-    def get_commodity_map(self):
-        return getters.get_commodity_map(self.ledger.entries)
+    def get_commodity_directives(self):
+        return getters.get_commodity_directives(self.ledger.entries)
 
     def realize(self):
         return self.ledger.root_account

--- a/fava_investor/modules/cashdrag/libcashdrag.py
+++ b/fava_investor/modules/cashdrag/libcashdrag.py
@@ -9,7 +9,7 @@ def find_cash_commodities(accapi, options):
 
     meta_label = options.get('metadata_label_cash', 'asset_allocation_Bond_Cash')
     cash_commodities = []
-    for commodity, declaration in accapi.get_commodity_map().items():
+    for commodity, declaration in accapi.get_commodity_directives().items():
         if declaration.meta.get(meta_label, 0) == 100:
             cash_commodities.append(commodity)
 


### PR DESCRIPTION
in the new version of beancount the `get_commodity_map` was changed to `get_commodity_directives`
And the `get_commodity_directives` removed the behavior that adds missing commodities, changed it accordingly.
#49 