### PR TITLE
Support fava's newly modified querytable macro

### DIFF
--- a/fava_investor/__init__.py
+++ b/fava_investor/__init__.py
@@ -1,6 +1,7 @@
 """Fava Investor: Investing related reports and tools for Beancount/Fava"""
 
 from fava.ext import FavaExtensionBase
+from fava import __version__ as fava_version
 
 from .modules.tlh import libtlh
 from .modules.assetalloc_class import libassetalloc
@@ -44,3 +45,16 @@ class Investor(FavaExtensionBase):  # pragma: no cover
     def recently_sold_at_loss(self):
         accapi = FavaInvestorAPI(self.ledger)
         return libtlh.recently_sold_at_loss(accapi, self.config.get('tlh', {}))
+
+    def use_new_querytable(self):
+        """
+        fava added the ledger as a first required argument to
+        querytable.querytable after version 1.18, so in order to support both,
+        we have to detect the version and adjust how we call it from inside our
+        template
+        """
+        split_version = fava_version.split('.')
+        if len(split_version) != 2:
+            split_version = split_version[:2]
+        major, minor = split_version
+        return int(major) > 1 or (int(major) == 1 and int(minor) > 18)

--- a/fava_investor/templates/Investor.html
+++ b/fava_investor/templates/Investor.html
@@ -1,5 +1,6 @@
 {% import "_query_table.html" as querytable with context %}
 {% import "_charts.html" as charts with context %}
+{% set new_querytable = extension.use_new_querytable() %}
 
 <i>Investor: Reports, analyses, and tools for investments.</i>
 
@@ -19,7 +20,11 @@
   {% else %}
     {% for portfolio in results %}
         <h3>{{portfolio[0]}}</h3>
-        {{ querytable.querytable(None, *portfolio[1]) }}
+        {% if new_querytable %}
+          {{ querytable.querytable(ledger, None, *portfolio[1]) }}
+        {% else %}
+          {{ querytable.querytable(None, *portfolio[1]) }}
+        {% endif %}
         <br />
     {% endfor %}
   {% endif %}
@@ -29,7 +34,11 @@
 {% if (module == 'cashdrag') %}
   <h2>Cash Drag Analysis</h2>
   {% set results = extension.build_cashdrag() %}
-  {{ querytable.querytable(None, *results) }}
+  {% if new_querytable %}
+    {{ querytable.querytable(ledger, None, *results) }}
+  {% else %}
+    {{ querytable.querytable(None, *results) }}
+  {% endif %}
 {% endif %}
 
 {% if (module == 'tlh') %}
@@ -59,14 +68,22 @@
     </div>
     <div class="column">
       <h3 style="text-align:left">Losses by Commodity</h3>
-      {{ querytable.querytable(None, *harvests[3]) }}
+      {% if new_querytable %}
+        {{ querytable.querytable(ledger, None, *harvests[3]) }}
+      {% else %}
+        {{ querytable.querytable(None, *harvests[3]) }}
+      {% endif %}
       <br />
     </div>
   </div>
 
 
   <h3>Candidates for tax loss harvesting</h3>
-  {{ querytable.querytable(None, *harvests[0]) }}
+  {% if new_querytable %}
+    {{ querytable.querytable(ledger, None, *harvests[0]) }}
+  {% else %}
+    {{ querytable.querytable(None, *harvests[0]) }}
+  {% endif %}
   <br />
 
 
@@ -75,7 +92,11 @@
   {% if harvests[2][0]|length == 0 %}
     {% set table_empty_msg = 'No purchases of the candidates above found within the last 30 days!' %}
   {% endif %}
-  {{ querytable.querytable(table_empty_msg, *harvests[2]) }}
+  {% if new_querytable %}
+    {{ querytable.querytable(ledger, table_empty_msg, *harvests[2]) }}
+  {% else %}
+    {{ querytable.querytable(table_empty_msg, *harvests[2]) }}
+  {% endif %}
   <br />
 
   <h3>What not to buy</h3>
@@ -87,7 +108,11 @@
   {% if lossy_sales[1]|length == 0 %}
     {% set table_empty_msg = 'No sales with losses found in the last 30 days!' %}
   {% endif %}
-  {{ querytable.querytable(table_empty_msg, *lossy_sales) }}
+  {% if new_querytable %}
+    {{ querytable.querytable(ledger, table_empty_msg, *lossy_sales) }}
+  {% else %}
+    {{ querytable.querytable(table_empty_msg, *lossy_sales) }}
+  {% endif %}
 
 
 {% endif %}


### PR DESCRIPTION
In the latest upstream fava code, its `querytable` macro has gained a positional argument. In order to support both new and old versions of fava, detect the fava version we're running against and adapt our templates to use the correct macro call accordingly.

Closes https://github.com/redstreet/fava_investor/issues/57