### PR TITLE
Use `url_for` instead of `url_for_current`

### DIFF
--- a/fava_investor/templates/Investor.html
+++ b/fava_investor/templates/Investor.html
@@ -7,7 +7,7 @@
 {% set module = request.args.get('module') %}
 <div class="headerline">
   {% for key, label in [('aa_class', _('Asset Allocation Classes')), ('aa_account', _('Asset Allocation Accounts')), ('cashdrag', _('Cash Drag')), ('tlh', _('Tax Loss Harvestor')) ] %}
-  <h3><b>{% if not (module == key) %}<a href="{{ url_for_current(module=key) }}">{{ label }}</a>{% else %} {{ label }}{% endif %}</b></h3>
+  <h3><b>{% if not (module == key) %}<a href="{{ url_for('extension_report', report_name='Investor', module=key) }}">{{ label }}</a>{% else %} {{ label }}{% endif %}</b></h3>
   {% endfor %}
 </div>
 


### PR DESCRIPTION
`url_for_current` has been removed in upstream fava, and `url_for` is
compatible both with future versions of fava and with older versions.

Closes https://github.com/redstreet/fava_investor/issues/59