### PR TITLE
Preserve costs during tax adjustment

### DIFF
--- a/fava_investor/modules/assetalloc_class/libassetalloc.py
+++ b/fava_investor/modules/assetalloc_class/libassetalloc.py
@@ -8,6 +8,7 @@ import re
 from beancount.core import convert
 from beancount.core import amount
 from beancount.core import inventory
+from beancount.core import position
 from beancount.core import realization
 from beancount.core.number import Decimal
 
@@ -176,8 +177,12 @@ def tax_adjust(realacc, accapi):
         """Scale inventory by tax adjustment"""
         scaled_balance = inventory.Inventory()
         for pos in balance.get_positions():
-            scaled_pos = amount.Amount(pos.units.number * (Decimal(tax_adj / 100)), pos.units.currency)
-            scaled_balance.add_amount(scaled_pos)
+            # One important assumption is that tax adjustment only ever encounters costs after realization, as
+            # having a cost spec for the total cost would change the cost per unit. 
+            assert pos.cost is None or isinstance(pos.cost, position.Cost)
+            
+            scaled_pos = pos * Decimal(tax_adj / 100)
+            scaled_balance.add_position(scaled_pos)
         return scaled_balance
 
     account_open_close = accapi.get_account_open_close()
@@ -197,7 +202,6 @@ def assetalloc(accapi, config={}):
     # print(realization.compute_balance(realacc).reduce(convert.get_units))
 
     balance = realization.compute_balance(realacc)
-    vbalance = balance.reduce(convert.get_units)
-    asset_buckets = bucketize(vbalance, accapi)
+    asset_buckets = bucketize(balance, accapi)
 
     return treeify(asset_buckets, accapi), realacc

--- a/fava_investor/modules/assetalloc_class/libassetalloc.py
+++ b/fava_investor/modules/assetalloc_class/libassetalloc.py
@@ -6,7 +6,6 @@ import collections
 import re
 
 from beancount.core import convert
-from beancount.core import amount
 from beancount.core import inventory
 from beancount.core import position
 from beancount.core import realization
@@ -178,9 +177,9 @@ def tax_adjust(realacc, accapi):
         scaled_balance = inventory.Inventory()
         for pos in balance.get_positions():
             # One important assumption is that tax adjustment only ever encounters costs after realization, as
-            # having a cost spec for the total cost would change the cost per unit. 
+            # having a cost spec for the total cost would change the cost per unit.
             assert pos.cost is None or isinstance(pos.cost, position.Cost)
-            
+
             scaled_pos = pos * Decimal(tax_adj / 100)
             scaled_balance.add_position(scaled_pos)
         return scaled_balance


### PR DESCRIPTION
Previously, tax adjustment discarded the cost of positions, causing `beancount.core.convert.convert_position` to miss some conversion paths via the cost currency. This necessitated a fallback to operating currencies for finding viable transitive conversions.

With this patch, tax adjustment preserves the cost of positions. Therefore, the cost currency is still available for automatic detection of transitive conversions when computing the asset allocation.

One important assumption is that tax adjustment only ever encounters costs after realization, as having a cost spec for the total cost would change the cost per unit. This assumption is checked via assert and has been manually tested without error on the multicurrency example.

The patch leaves the fallback logic for conversion via operating currencies in place as an alternative when conversion via cost currency fails.

Fixes #82 