### PR TITLE
Fix for fava 1.2.5

### DIFF
--- a/fava_investor/__init__.py
+++ b/fava_investor/__init__.py
@@ -62,6 +62,8 @@ class Investor(FavaExtensionBase):  # pragma: no cover
         we have to detect the version and adjust how we call it from inside our
         template
         """
+        if "dev" in fava_version:
+            return True
         split_version = fava_version.split('.')
         if len(split_version) != 2:
             split_version = split_version[:2]

--- a/fava_investor/common/beancountinvestorapi.py
+++ b/fava_investor/common/beancountinvestorapi.py
@@ -48,7 +48,7 @@ class AccAPI:
 
     def get_operating_currencies_regex(self):
         currencies = self.get_operating_currencies()
-        return '(' + '|'.join(map(lambda cur: f'^cur$', currencies)) + ')'
+        return '(' + '|'.join(map(lambda cur: '^cur$', currencies)) + ')'
 
     def get_account_open_close(self):
         return getters.get_account_open_close(self.entries)

--- a/fava_investor/common/beancountinvestorapi.py
+++ b/fava_investor/common/beancountinvestorapi.py
@@ -48,7 +48,7 @@ class AccAPI:
 
     def get_operating_currencies_regex(self):
         currencies = self.get_operating_currencies()
-        return '(' + '|'.join(currencies) + ')'
+        return '(' + '|'.join(map(lambda cur: f'^cur$', currencies)) + ')'
 
     def get_account_open_close(self):
         return getters.get_account_open_close(self.entries)

--- a/fava_investor/common/favainvestorapi.py
+++ b/fava_investor/common/favainvestorapi.py
@@ -39,7 +39,7 @@ class FavaInvestorAPI:
 
     def get_operating_currencies_regex(self):
         currencies = self.get_operating_currencies()
-        return '(' + '|'.join(currencies) + ')'
+        return '(' + '|'.join(map(lambda cur: f'^cur$', currencies)) + ')'
 
     def get_account_open_close(self):
         return getters.get_account_open_close(g.filtered.entries)

--- a/fava_investor/common/favainvestorapi.py
+++ b/fava_investor/common/favainvestorapi.py
@@ -7,7 +7,7 @@ from fava.context import g
 
 class FavaInvestorAPI:
     def build_price_map(self):
-        return g.ledger.price_map
+        return g.ledger.prices
 
     def build_filtered_price_map(self, pcur, base_currency):
         """pcur and base_currency are currency strings"""

--- a/fava_investor/common/favainvestorapi.py
+++ b/fava_investor/common/favainvestorapi.py
@@ -28,7 +28,7 @@ class FavaInvestorAPI:
     def query_func(self, sql):
         # Based on the fava version, determine if we need to add a new
         # positional argument to fava's execute_query()
-        if version.parse(fava_version) >= version.parse("1.22"):
+        if version.parse(fava_version) >= version.parse("1.22") or "dev" in fava_version:
             _, rtypes, rrows = g.ledger.query_shell.execute_query(g.filtered.entries, sql)
         else:
             _, rtypes, rrows = g.ledger.query_shell.execute_query(sql)

--- a/fava_investor/common/favainvestorapi.py
+++ b/fava_investor/common/favainvestorapi.py
@@ -39,7 +39,7 @@ class FavaInvestorAPI:
 
     def get_operating_currencies_regex(self):
         currencies = self.get_operating_currencies()
-        return '(' + '|'.join(map(lambda cur: f'^cur$', currencies)) + ')'
+        return '(' + '|'.join(map(lambda cur: '^cur$', currencies)) + ')'
 
     def get_account_open_close(self):
         return getters.get_account_open_close(g.filtered.entries)

--- a/fava_investor/common/libinvestor.py
+++ b/fava_investor/common/libinvestor.py
@@ -4,6 +4,7 @@ import collections
 import decimal
 from beancount.core.inventory import Inventory
 from beancount.core import convert
+from fava.core.conversion import convert_position
 
 
 class Node(object):
@@ -74,7 +75,7 @@ def build_table_footer(types, rows, accapi):
         total = ''
         if t == Inventory:
             total = sum_inventories([getattr(r, label) for r in rows])
-            total = total.reduce(convert.convert_position, accapi.get_operating_currencies()[0],
+            total = total.reduce(convert_position, accapi.get_operating_currencies()[0],
                                  accapi.build_price_map())
         elif t == decimal.Decimal:
             total = sum([getattr(r, label) for r in rows])

--- a/fava_investor/modules/assetalloc_class/libassetalloc.py
+++ b/fava_investor/modules/assetalloc_class/libassetalloc.py
@@ -5,6 +5,7 @@ from fava_investor.common.libinvestor import Node
 import collections
 import re
 
+from fava.core.conversion import convert_position
 from beancount.core import convert
 from beancount.core import inventory
 from beancount.core import position
@@ -100,7 +101,7 @@ def bucketize(vbalance, accapi):
 
         # what we want is the conversion to be done on the end date, or on a date
         # closest to it, either earlier or later. convert_position does this via bisect
-        amount = convert.convert_position(pos, base_currency, price_map, date=end_date)
+        amount = convert_position(pos, base_currency, price_map, date=end_date)
         if amount.currency == pos.units.currency and amount.currency != base_currency:
             # Ideally, we would automatically figure out the currency to hop via, based on the cost
             # currency of the position. However, with vbalance, cost currency info is not

--- a/fava_investor/modules/cashdrag/libcashdrag.py
+++ b/fava_investor/modules/cashdrag/libcashdrag.py
@@ -16,7 +16,7 @@ def find_cash_commodities(accapi, options):
     operating_currencies = accapi.get_operating_currencies()
     cash_commodities += operating_currencies
     cash_commodities = set(cash_commodities)
-    commodities_pattern = '(' + '|'.join(cash_commodities) + ')'
+    commodities_pattern = '(' + '|'.join(map(lambda cur: f'^{cur}$', cash_commodities)) + ')'
     return commodities_pattern, operating_currencies[0]
 
 

--- a/fava_investor/modules/summarizer/libsummarizer.py
+++ b/fava_investor/modules/summarizer/libsummarizer.py
@@ -8,6 +8,7 @@ from beancount.core.data import Close
 from beancount.core import realization
 from beancount.core import convert
 from fava_investor.common.libinvestor import build_table_footer
+from fava.core.conversion import convert_position
 
 
 # TODO:

--- a/fava_investor/templates/Investor.html
+++ b/fava_investor/templates/Investor.html
@@ -1,5 +1,4 @@
 {% import "_query_table.html" as querytable with context %}
-{% import "_charts.html" as charts with context %}
 {% set new_querytable = extension.use_new_querytable() %}
 
 {% set module = request.args.get('module') %}
@@ -11,7 +10,7 @@
                         ('summarizer', _('Summarizer')),
                         ('minimizegains', _('Gains Minimizer'))
                         ] %}
-  <h3><b>{% if not (module == key) %}<a href="{{ url_for('extension_report', report_name='Investor', module=key) }}">{{ label }}</a>{% else %} {{ label }}{% endif %}</b></h3>
+  <h3><b>{% if not (module == key) %}<a href="{{ url_for('extension_report', extension_name='Investor', module=key) }}">{{ label }}</a>{% else %} {{ label }}{% endif %}</b></h3>
   {% endfor %}
 </div>
 
@@ -22,8 +21,6 @@ implemented as a collection of modules. Use the tabs on the top to navigate to e
 module.
 </i>
 {% endif %}
-
-<svelte-component type="charts"></svelte-component>
 
 <!-- -------------------------------------------------------------------------------- -->
 {% macro table_list_renderer(title, tables) -%}
@@ -206,7 +203,7 @@ Hold Ctrl or Cmd while clicking to expand one level.') %}
 {% endmacro %}
 
 {% macro asset_allocation_hierarchy(serialised_tree, label='Asset Allocation') %}
-{% do charts.chart_data.append({
+{% do chart_data.append({
 'type': 'hierarchy',
 'label': label,
 'data': {
@@ -219,10 +216,11 @@ Hold Ctrl or Cmd while clicking to expand one level.') %}
 {% if (module == 'aa_class') %}
   <h2>Portfolio: Asset Allocation by Class</h2>
 
+  {% set chart_data = [] %}
   {% set results = extension.build_assetalloc_by_class() %}
 
   {{ asset_allocation_hierarchy(results[0].serialise(results[0]['currency']), label='Asset Allocation') }}
-  <svelte-component type="charts"><script type="application/json">{{ charts.chart_data|tojson }}</script></svelte-component>
+  <svelte-component type="charts"><script type="application/json">{{ chart_data|tojson }}</script></svelte-component>
 
   {{ asset_tree(results[0]) }}
 


### PR DESCRIPTION
This is initial work on  #84

This probably shouldn't be merged as is, but this should be most of the changes required to get everything working with fava 1.2.5. The main changes are switching from convert.convert_position to fava's built-in convert_position, and some modifications to the charts api.
The one case I haven't fixed is in libassetalloc.py, under the `if amount.currency == pos.units.currency and amount.currency != base_currency` case. As far as I can tell, fava's convert_position doesn't support `via`, so I wasn't sure what to do with that block.

I also made it so that the generated currency regexes use ^ and $ so that substrings are not incorrectly matched.

Finally, I modified a few version checks to be able to detect development versions of fava. I have a situation where I am installing fava from a local repository, and the installed fava version ends up as 0.1.dev[commit hash], so the version checks are detecting an older version of fava. My thought was that if you are using a development version of fava, it's probably safe to assume that the fava version is up to date and the newest APIs should be used. Feel free to remove those sections of the change if you want, I can work around  that on my end if you don't want to merge a sort of hacky check.

I also haven't used fava_investor before. I made these fixes as part of setting up fava_investor, so I don't have a reference for how everything looked/worked before fava 1.2.5 broke things, so apologies if some of the changes break some stuff that I didn't notice.