### PR TITLE
Make currency regex not incorrectly match substrings

### DIFF
--- a/fava_investor/modules/cashdrag/libcashdrag.py
+++ b/fava_investor/modules/cashdrag/libcashdrag.py
@@ -11,10 +11,10 @@ def find_cash_commodities(accapi, options):
     cash_commodities = []
     for commodity, declaration in accapi.get_commodity_directives().items():
         if declaration.meta.get(meta_label, 0) == 100:
-            cash_commodities.append(commodity)
+            cash_commodities.append(f'^{commodity}$')
 
     operating_currencies = accapi.get_operating_currencies()
-    cash_commodities += operating_currencies
+    cash_commodities += map(lambda cur: f'^{cur}$', operating_currencies)
     cash_commodities = set(cash_commodities)
     commodities_pattern = '(' + '|'.join(cash_commodities) + ')'
     return commodities_pattern, operating_currencies[0]


### PR DESCRIPTION
This changes the currency regexes use '^<currency>$' instead of just matching '<currency>', so that specifying a currency only matches that currency exactly, instead of also matching currencies that contain the specified currency.