### PR TITLE
remove dead code for Fava <v1.18

### DIFF
--- a/fava_investor/__init__.py
+++ b/fava_investor/__init__.py
@@ -1,7 +1,6 @@
 """Fava Investor: Investing related reports and tools for Beancount/Fava"""
 
 from fava.ext import FavaExtensionBase
-from fava import __version__ as fava_version
 
 from .modules.tlh import libtlh
 from .modules.assetalloc_class import libassetalloc
@@ -54,16 +53,3 @@ class Investor(FavaExtensionBase):  # pragma: no cover
     def recently_sold_at_loss(self):
         accapi = FavaInvestorAPI()
         return libtlh.recently_sold_at_loss(accapi, self.config.get('tlh', {}))
-
-    def use_new_querytable(self):
-        """
-        fava added the ledger as a first required argument to
-        querytable.querytable after version 1.18, so in order to support both,
-        we have to detect the version and adjust how we call it from inside our
-        template
-        """
-        split_version = fava_version.split('.')
-        if len(split_version) != 2:
-            split_version = split_version[:2]
-        major, minor = split_version
-        return int(major) > 1 or (int(major) == 1 and int(minor) > 18)

--- a/fava_investor/templates/Investor.html
+++ b/fava_investor/templates/Investor.html
@@ -1,5 +1,4 @@
 {% import "_query_table.html" as querytable with context %}
-{% set new_querytable = extension.use_new_querytable() %}
 
 {% set module = request.args.get('module') %}
 <div class="headerline">
@@ -30,11 +29,7 @@ module.
 {% endif %}
 {% for table in tables %}
   <h2>{{table[0]}}</h2>
-  {% if new_querytable %}
-    {{ querytable.querytable(ledger, None, *table[1]) }}
-  {% else %}
-    {{ querytable.querytable(None, *table[1]) }}
-  {% endif %}
+  {{ querytable.querytable(ledger, None, *table[1]) }}
 {% endfor %}
 {% endmacro %}
 <!-- -------------------------------------------------------------------------------- -->
@@ -84,22 +79,15 @@ module.
     </div>
     <div class="column">
       <h3 style="text-align:left">Losses by Commodity</h3>
-      {% if new_querytable %}
-        {{ querytable.querytable(ledger, None, *harvests[3]) }}
-      {% else %}
-        {{ querytable.querytable(None, *harvests[3]) }}
-      {% endif %}
+      {{ querytable.querytable(ledger, None, *harvests[3]) }}
       <br />
     </div>
   </div>
 
 
   <h3>Candidates for tax loss harvesting</h3>
-  {% if new_querytable %}
-    {{ querytable.querytable(ledger, None, *harvests[0]) }}
-  {% else %}
-    {{ querytable.querytable(None, *harvests[0]) }}
-  {% endif %}
+  {{ querytable.querytable(ledger, None, *harvests[0]) }}
+
   <br />
 
 
@@ -112,11 +100,7 @@ module.
   {% if harvests[2][0]|length == 0 %}
     {% set table_empty_msg = 'No purchases of the candidates above found within the last 30 days!' %}
   {% endif %}
-  {% if new_querytable %}
-    {{ querytable.querytable(ledger, table_empty_msg, *harvests[2]) }}
-  {% else %}
-    {{ querytable.querytable(table_empty_msg, *harvests[2]) }}
-  {% endif %}
+  {{ querytable.querytable(ledger, table_empty_msg, *harvests[2]) }}
   <br />
 
   <h3>What not to buy</h3>
@@ -128,11 +112,7 @@ module.
   {% if lossy_sales[1]|length == 0 %}
     {% set table_empty_msg = 'No sales with losses found in the last 30 days!' %}
   {% endif %}
-  {% if new_querytable %}
-    {{ querytable.querytable(ledger, table_empty_msg, *lossy_sales) }}
-  {% else %}
-    {{ querytable.querytable(table_empty_msg, *lossy_sales) }}
-  {% endif %}
+  {{ querytable.querytable(ledger, table_empty_msg, *lossy_sales) }}
 
   <br>
   <i>None of the above is meant to be financial, legal, tax, or other advice.</i>


### PR DESCRIPTION
While working on #90, I noticed this basically dead code which checks for Fava versions <1.18, while setup.py already requires 1.23
