### PR TITLE
Fix assetalloc_class chart

### DIFF
--- a/fava_investor/modules/assetalloc_class/libassetalloc.py
+++ b/fava_investor/modules/assetalloc_class/libassetalloc.py
@@ -28,6 +28,7 @@ class AssetClassNode(Node):
             "balance_children": {currency: self.balance_children},
             "balance": {currency: self.balance},
             "children": children,
+            "has_txns": False,
         }
 
     def pretty_print(self, indent=0):

--- a/fava_investor/templates/Investor.html
+++ b/fava_investor/templates/Investor.html
@@ -185,11 +185,13 @@ Hold Ctrl or Cmd while clicking to expand one level.') %}
 {% if (module == 'aa_class') %}
   <h2>Portfolio: Asset Allocation by Class</h2>
 
-  {% set chart_data = [] %}
   {% set results = extension.build_assetalloc_by_class() %}
-
-  {% set serialised_tree = results[0].serialise(results[0]['currency']) %}
-  {% set chart_data = [{ 'type': 'hierarchy', 'label': 'Asset Allocation', 'data': serialised_tree }] %}
+  {% set chart_data = [{
+    'type': 'hierarchy',
+    'label': "Asset Allocation",
+    'data': results[0].serialise(results[0]['currency'])
+    }]
+  %}
   <svelte-component type="charts"><script type="application/json">{{ chart_data|tojson }}</script></svelte-component>
 
   {{ asset_tree(results[0]) }}


### PR DESCRIPTION
The chart showing asset allocation by class is currently broken on `main` because of a schema change that prevents correct deserialisation. This PR fixes the issue (took me a while to figure it out because the JS code swallows the error).