### PR TITLE
Ignore commodities without price

### DIFF
--- a/fava_investor/modules/assetalloc_class/libassetalloc.py
+++ b/fava_investor/modules/assetalloc_class/libassetalloc.py
@@ -112,9 +112,10 @@ def bucketize(vbalance, accapi):
             amount = convert.convert_amount(pos.units, base_currency, b_price_map,
                                             via=operating_currencies, date=end_date)
             if amount.currency != base_currency:
-                sys.stderr.write("Error: unable to convert {} to base currency {}"
-                                 " (Missing price directive?)\n".format(pos, base_currency))
-                sys.exit(1)
+                print("Warning: unable to convert {} to base currency {}"
+                      " (Missing price directive?)\n"
+                      "Skipping it...".format(pos, base_currency))
+                continue
 
         commodity = pos.units.currency
         metas = {} if commodities.get(commodity) is None else commodities[commodity].meta


### PR DESCRIPTION
Some commodities in my ledger do not have a price, nor are meant to have one. 

Before, I was getting the following error:

```bash
Error: unable to convert 1 XXX to base currency YYY (Missing price directive?)
```

As a result, `fava` was also exiting.

This PR simply ignores those commodities.